### PR TITLE
Feature/fixsetup

### DIFF
--- a/src/Squirrel/UpdateManager.cs
+++ b/src/Squirrel/UpdateManager.cs
@@ -230,7 +230,7 @@ namespace Squirrel
                 IDisposable theLock;
                 try {
                     theLock = ModeDetector.InUnitTestRunner() ?
-                        Disposable.Create(() => {}) : new SingleGlobalInstance(key, TimeSpan.FromMilliseconds(2000));
+                        Disposable.Create(() => {}) : new SingleGlobalInstance(key, TimeSpan.FromMilliseconds(10000));
                 } catch (TimeoutException) {
                     throw new TimeoutException("Couldn't acquire update lock, another instance may be running updates");
                 }

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -589,6 +589,7 @@ namespace Squirrel
             var path = Path.Combine(Path.GetTempPath(), ".squirrel-lock-" + key);
 
             var st = new Stopwatch();
+            this.Log().Info("Grabbing lockfile with timeout of " + timeOut);
             st.Start();
 
             var fh = default(FileStream);

--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -210,6 +210,8 @@ namespace Squirrel
                     textResult = String.Empty;
                 }
             }
+
+            Log().Debug("Received exitcode {0} from process {1}", pi.ExitCode, psi.FileName);
             return Tuple.Create(pi.ExitCode, textResult.Trim());
         }
 

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -249,8 +249,6 @@ namespace Squirrel.Update
           using (var mgr = new UpdateManager(updateUrl, appName, FrameworkVersion.Net45)) {
             var updateInfo = await mgr.CheckForUpdate(progress: x => Console.WriteLine(x / 3));
 
-            var releaseNotes = updateInfo.FetchReleaseNotes();
-
             var sanitizedUpdateInfo = new
             {
               currentVersion = updateInfo.CurrentlyInstalledVersion != null ? updateInfo.CurrentlyInstalledVersion.Version.ToString() : "",
@@ -258,7 +256,7 @@ namespace Squirrel.Update
               releasesToApply = updateInfo.ReleasesToApply.Select(x => new
               {
                 version = x.Version.ToString(),
-                releaseNotes = releaseNotes.ContainsKey(x) ? releaseNotes[x] : "",
+                releaseNotes = "", // releaseNotes require we've downloaded the package already. In this case, we have not.
               }).ToArray(),
             };
 


### PR DESCRIPTION
Fixes a few high priority UX bugs in the installer.
- Uninstall now attempts to delete its folder 10 times (with a 1 second sleep between each). This fixes our "not everything is uninstalled upon uninstall" issue. Update.exe unfortunately remains.
- Updating now waits 10 seconds instead of 2 seconds to acquire the global squirrel lock. This fixes the issue where upon the first launch updating would immediately fail, because the installer was still running and had the squirrel lock.
- Checking no longer attempts to return release notes, since they are guaranteed to not be present. ReleaseNotes come from the nuget, which we are not downloading in Check.
- Just some extra logging too.
