### PR TITLE
Make directory deletion more atomic

### DIFF
--- a/src/Squirrel/Utility.cs
+++ b/src/Squirrel/Utility.cs
@@ -342,7 +342,7 @@ namespace Squirrel
             return Disposable.Create(() => File.Delete(thePath));
         }
 
-        public static async Task DeleteDirectory(string directoryPath)
+        public static async Task DeleteDirectory(string directoryPath, bool moveFirst = true)
         {
             Contract.Requires(!String.IsNullOrEmpty(directoryPath));
 
@@ -352,6 +352,24 @@ namespace Squirrel
                 Log().Warn("DeleteDirectory: does not exist - {0}", directoryPath);
                 return;
             }
+            var originalPath = "";
+            if (moveFirst) {
+                // We want directory deletion to be relatively atomic
+                // either delete the whole tree or nothing at all
+                // Unfortunately, there doesn't seem to be a great way to do that
+                // So we do the next best thing, we rename the directory and then delete it
+                // If any of the files inside are locked, the move will fail
+                // After the directory is renamed, any attempts to access files at the old path
+                // will also fail, making it less likely for them to be locked mid-deletion
+                if (directoryPath.Last() == Path.DirectorySeparatorChar) {
+                    directoryPath = directoryPath.Remove(directoryPath.Length - 1);
+                }
+                var parent = Path.GetDirectoryName(directoryPath);
+                originalPath = directoryPath;
+                directoryPath = parent + Path.DirectorySeparatorChar + "tmp" + Path.GetRandomFileName ();
+                Directory.Move(originalPath, directoryPath);
+            }
+            
 
             // From http://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true/329502#329502
             var files = new string[0];
@@ -376,7 +394,7 @@ namespace Squirrel
             });
 
             var directoryOperations =
-                dirs.ForEachAsync(async dir => await DeleteDirectory(dir));
+                dirs.ForEachAsync(async dir => await DeleteDirectory(dir, false));
 
             await Task.WhenAll(fileOperations, directoryOperations);
 
@@ -388,6 +406,12 @@ namespace Squirrel
             } catch (Exception ex) {
                 var message = String.Format("DeleteDirectory: could not delete - {0}", directoryPath);
                 Log().ErrorException(message, ex);
+                if (moveFirst) {
+                    // move back to original name so we can try again on the next run
+                    Directory.Move(directoryPath, originalPath);
+                }
+                
+                throw ex;
             }
         }
 

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -239,7 +239,7 @@ namespace Squirrel.Update
                 if (Directory.Exists(mgr.RootAppDirectory)) {
                     this.Log().Warn("Install path {0} already exists, burning it to the ground", mgr.RootAppDirectory);
 
-                    await this.ErrorIfThrows(() => Utility.DeleteDirectory(mgr.RootAppDirectory),
+                    await this.ErrorIfThrows(() => Utility.DeleteDirectory(mgr.RootAppDirectory, true),
                         "Failed to remove existing directory on full install, is the app still running???");
 
                     this.ErrorIfThrows(() => Utility.Retry(() => Directory.CreateDirectory(mgr.RootAppDirectory), 3),


### PR DESCRIPTION
Currently, if a file is locked in the destination directory (which will be the case if the app is running), it will end up partially deleted and the installation will exit with an error. This leaves the existing install in a corrupted state, which is less than ideal. This PR makes deletes sort-of atomic by first renaming the directory before deleting it. This rename will fail if the app is currently running or if the contents of the directory happen to be locked for some other reason